### PR TITLE
added ability to disable card stacking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.1.0-beta7](https://github.com/sixoverground/VerticalCardSwiper/releases/tag/0.1.0-beta7) (Nov 27, 2018)
+
+#### Enhancements
+
+- Added  `isStackingEnabled` to `VerticalCardSwiper`.
+
 ## [0.1.0-beta6](https://github.com/JoniVR/VerticalCardSwiper/releases/tag/0.1.0-beta6) (Nov 15, 2018)
 
 #### Enhancements

--- a/Example/ExampleViewController.swift
+++ b/Example/ExampleViewController.swift
@@ -48,6 +48,7 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDelegate, Verti
         
         cardSwiper.delegate = self
         cardSwiper.datasource = self
+        cardSwiper.isStackingEnabled = false
         
         // register cardcell for storyboard use
         cardSwiper.register(nib: UINib(nibName: "ExampleCell", bundle: nil), forCellWithReuseIdentifier: "ExampleCell")

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ class ExampleViewController: UIViewController, VerticalCardSwiperDatasource {
 @IBInspectable public var visibleNextCardHeight: CGFloat = 50
 /// Vertical spacing between CardCells. Default is 40.
 @IBInspectable public var cardSpacing: CGFloat = 40
+/// Stack the cards. Default is `true`.
+@IBInspectable public var isStackingEnabled: Bool = true
 ```
 
 #### Other

--- a/Sources/VerticalCardSwiper.swift
+++ b/Sources/VerticalCardSwiper.swift
@@ -81,6 +81,12 @@ public class VerticalCardSwiper: UIView {
             flowLayout.isPreviousCardVisible = newValue
         }
     }
+    /// Stack the cards. Default is `true`.
+    @IBInspectable public var isStackingEnabled: Bool = true {
+        willSet {
+            flowLayout.isStackingEnabled = newValue
+        }
+    }
     
     public weak var delegate: VerticalCardSwiperDelegate?
     public weak var datasource: VerticalCardSwiperDatasource? {
@@ -112,6 +118,7 @@ public class VerticalCardSwiper: UIView {
         flowLayout.firstItemTransform = firstItemTransform
         flowLayout.minimumLineSpacing = cardSpacing
         flowLayout.isPagingEnabled = true
+        flowLayout.isStackingEnabled = true
         return flowLayout
     }()
     

--- a/Sources/VerticalCardSwiperFlowLayout.swift
+++ b/Sources/VerticalCardSwiperFlowLayout.swift
@@ -33,6 +33,8 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
     internal var cellHeight: CGFloat!
     /// Allows you to make the previous card visible or not visible (stack effect). Default is `true`.
     internal var isPreviousCardVisible: Bool = true
+    /// Disable card stacking
+    internal var isStackingEnabled: Bool = true
     
     internal override func prepare() {
         super.prepare()
@@ -131,22 +133,24 @@ internal class VerticalCardSwiperFlowLayout: UICollectionViewFlowLayout {
         let translationScale = CGFloat((attributes.zIndex + 1) * 10)
         
         // Card stack effect
-        if let itemTransform = firstItemTransform {
-            let scale = 1 - deltaY * itemTransform
-            
-            var t = CGAffineTransform.identity
-            
-            t = t.scaledBy(x: scale, y: 1)
-            if isPreviousCardVisible {
-                t = t.translatedBy(x: 0, y: (deltaY * translationScale))
-            }
+        if isStackingEnabled {
+            if let itemTransform = firstItemTransform {
+                let scale = 1 - deltaY * itemTransform
 
-            attributes.transform = t
+                var t = CGAffineTransform.identity
+
+                t = t.scaledBy(x: scale, y: 1)
+                if isPreviousCardVisible {
+                    t = t.translatedBy(x: 0, y: (deltaY * translationScale))
+                }
+
+                attributes.transform = t
+            }
         }
         
         origin.x = (self.collectionView?.frame.width)! / 2 - attributes.frame.width / 2 - (self.collectionView?.contentInset.left)!
         origin.y = finalY
-        attributes.frame = CGRect(origin: origin, size: attributes.frame.size)
+        if isStackingEnabled { attributes.frame = CGRect(origin: origin, size: attributes.frame.size) }
         attributes.zIndex = attributes.indexPath.row
     }
 }

--- a/VerticalCardSwiper.podspec
+++ b/VerticalCardSwiper.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'VerticalCardSwiper'
-  s.version          = '0.1.0-beta6'
+  s.version          = '0.1.0-beta7'
   s.summary          = 'A marriage between the Shazam Discover UI and Tinder, built with UICollectionView in Swift.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
<!-- Thanks for contributing to _VerticalCardSwiper_. Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- [x] I've tested my changes.
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md).
- [x] I've updated the documentation if necessary.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
There is a use case to not display a deck of cards under the current card.
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe how you tested your changes. --->
Ran test suite, plus manually tested on wide range of devices. 

### Description
<!--- Describe your changes in detail. -->
Currently, the previously viewed cards are always displayed in a deck underneath the current card. This prevents the ability to display interactive feedback behind the card when swiping left or right. Disabling the stack provides a clear area to perform other UI actions behind the swappable cards.